### PR TITLE
fix google fonts imports warning by tailwind

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 body {
   @apply bg-black text-white;


### PR DESCRIPTION
Warning only appears when the site loads but not when the server starts.
<img width="912" alt="Screenshot 2024-10-02 at 11 32 03 AM" src="https://github.com/user-attachments/assets/bfca500f-198c-4f18-8d9e-8331b7af6675">
